### PR TITLE
Fix bool value unmaershaling

### DIFF
--- a/lsblk.go
+++ b/lsblk.go
@@ -38,11 +38,11 @@ type Blockdevice struct {
 	Partuuid     string      // partition UUID
 	Partflags    string      // partition flags
 	Ra           json.Number // read-ahead of the devic
-	Ro           bool        // read-only device
-	Rm           bool        // removable device
-	Hotplug      bool        // removable or hotplug device (usb, pcmcia, ...)
-	Rota         bool        // rotational device
-	Rand         bool        // adds randomness
+	Ro           Bool        // read-only device
+	Rm           Bool        // removable device
+	Hotplug      Bool        // removable or hotplug device (usb, pcmcia, ...)
+	Rota         Bool        // rotational device
+	Rand         Bool        // adds randomness
 	Model        string      // device identifier
 	Serial       string      // disk serial number
 	Size         Num         // size of the device in bytes
@@ -61,7 +61,7 @@ type Blockdevice struct {
 	Discaln      json.Number `json:"disc-aln"`  // discard alignment offset
 	Discgran     json.Number `json:"disc-gran"` // discard granularity
 	Discmax      json.Number `json:"disc-max"`  // discard max bytes
-	Disczero     bool        `json:"disc-zero"` // discard zeroes data
+	Disczero     Bool        `json:"disc-zero"` // discard zeroes data
 	Wsame        json.Number // write same max bytes
 	Wwn          string      // unique storage identifier
 	Hctl         string      // Host:Channel:Target:Lun for SCSI
@@ -70,7 +70,7 @@ type Blockdevice struct {
 	Rev          string      // device revision
 	Vendor       string      // device vendor
 	Zoned        string      // zone model
-	Dax          bool        // dax-capable device
+	Dax          Bool        // dax-capable device
 	Children     []Blockdevice
 	// HumanReadableSize func(j *json.Number)
 }

--- a/lsblk.go
+++ b/lsblk.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"reflect"
+	"strconv"
+	"strings"
 )
 
 // Lsblk main JSON struct to capture the output of `lsblk`
@@ -138,6 +140,26 @@ func (b *Blockdevice) UnmarshalJSON(data []byte) error {
 	// 	a.String = s
 	// 	b.Fsavail = a
 	// }
+	return nil
+}
+
+// Bool custom field deal with string, int and bool value
+type Bool bool
+
+// UnmarshalJSON custom marshaling of the JSON fields
+func (b *Bool) UnmarshalJSON(data []byte) (err error) {
+	switch str := strings.ToLower(strings.Trim(string(data), `"`)); str {
+	case "true":
+		*b = true
+	case "false":
+		*b = false
+	default:
+		val, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return err
+		}
+		*b = val > 0
+	}
 	return nil
 }
 


### PR DESCRIPTION
Some system will output integer instead of `true` or `false` for fields like `ro`, here's an example:
```json
{
   "blockdevices": [
      {"name": "nvme3n1", "maj:min": "259:0", "rm": "0", "size": "*****559*****", "ro": "0", "type": "disk", "mountpoint": null,
         "children": [
            {"name": "nvme3n1p1", "maj:min": "259:13", "rm": "0", "size": "*****559*****", "ro": "0", "type": "part", "mountpoint": null}
         ]
      },
     ...
   ]
}
```
We need a customized field that can handle the integer scenario. With the fix, we can handle the situation where user use string, integer or bool value for those boolean fields.